### PR TITLE
Repeated use of same table exception as one map

### DIFF
--- a/src/org/purefn/sqlium/dsl/analyze.clj
+++ b/src/org/purefn/sqlium/dsl/analyze.clj
@@ -190,8 +190,8 @@
         repeated (repeated-join-tables (:one promoted-relationships))]
     (when repeated
       (throw (ex-info "Invalid relationships detected - repeated use of the same table."
-                      {:repeated repeated}
-                      {:source-table (dissoc table :fields)})))
+                      {:repeated repeated
+                       :source-table (dissoc table :fields)})))
     (assoc table
            :fields fields
            :relationships promoted-relationships)))


### PR DESCRIPTION
Ex-info takes one map and will throw a `java.lang.Throwable` error when passed two maps. 